### PR TITLE
Fix output of version during startup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ VERSION               := $(shell cat VERSION)
 IMAGE_TAG             := $(VERSION)
 EFFECTIVE_VERSION     := $(VERSION)-$(shell git rev-parse HEAD)
 GOARCH                := amd64
+LD_FLAGS              := $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
 
 TOOLS_DIR := hack/tools
 include $(TOOLS_DIR)/tools.mk
@@ -24,13 +25,13 @@ tidy:
 build-local:
 	@CGO_ENABLED=1 go build -o $(EXECUTABLE) \
 		-race \
-		-ldflags "-X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)'"\
+		-ldflags "-X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)' $(LD_FLAGS)"\
 		cmd/ext-authz-server/main.go
 
 .PHONY: release
 release:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o $(EXECUTABLE) \
-        -ldflags "-w -X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)'"\
+        -ldflags "-w -X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)' $(LD_FLAGS)"\
 		cmd/ext-authz-server/main.go
 
 .PHONY: check

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+PACKAGE_PATH="${1:-k8s.io/component-base}"
+VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+PROGRAM_NAME="${3:-Gardener}"
+BUILD_DATE="${4:-$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')}"
+VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
+VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+
+MAJOR_VERSION=""
+MINOR_VERSION=""
+
+if [[ "${VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+  MAJOR_VERSION=${BASH_REMATCH[1]}
+  MINOR_VERSION=${BASH_REMATCH[2]}
+  if [[ -n "${BASH_REMATCH[4]}" ]]; then
+    MINOR_VERSION+="+"
+  fi
+fi
+
+# .dockerignore ignores all files unrelevant for build (e.g. docs) to only copy relevant source files to the build
+# container. Hence, git will always detect a dirty work tree when building in a container (many deleted files).
+# This command filters out all deleted files that are ignored by .dockerignore to only detect changes to relevant files
+# as a dirty work tree.
+# Additionally, it filters out changes to the `VERSION` file, as this is currently the only way to inject the
+# version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
+TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files -o --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
+
+echo "-X $PACKAGE_PATH/version.gitMajor=$MAJOR_VERSION
+      -X $PACKAGE_PATH/version.gitMinor=$MINOR_VERSION
+      -X $PACKAGE_PATH/version.gitVersion=$VERSION
+      -X $PACKAGE_PATH/version.gitTreeState=$TREE_STATE
+      -X $PACKAGE_PATH/version.gitCommit=$(git rev-parse --verify HEAD)
+      -X $PACKAGE_PATH/version.buildDate=$BUILD_DATE
+      -X $PACKAGE_PATH/version/verflag.programName=$PROGRAM_NAME"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Fix output of version during startup.

Previously, the output looked like this:

```
2026-02-17T16:32:15.882Z	INFO	Starting ext-authz-server	{"version": "v0.0.0-master+$Format:%H$"}
```

After this change, it looks properly:

```
2026-02-18T08:13:46.058+0100	INFO	Starting ext-authz-server	{"version": "v0.1.0-dev"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The version output during startup was fixed.
```
