### PR TITLE
Propagate critical errors to the default output

### DIFF
--- a/cmd/ext-authz-server/main.go
+++ b/cmd/ext-authz-server/main.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/gardener/gardener/cmd/utils"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
@@ -17,6 +15,6 @@ func main() {
 	utils.DeduplicateWarnings()
 
 	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
-		os.Exit(1)
+		panic(err)
 	}
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Propagate critical errors to the default output.

Previously, the program just exited whenever there was a critical error during execution. Now, it at least prints the error so that operators can take proper actions to deal with the error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Critical errors are now logged before shutting down the program.
```
