### PR TITLE
Add support for TLS and enable it by default

### DIFF
--- a/cmd/ext-authz-server/app/app.go
+++ b/cmd/ext-authz-server/app/app.go
@@ -49,7 +49,7 @@ func run(ctx context.Context, log logr.Logger, o *options) error {
 	port := o.port
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		return fmt.Errorf("failed to listen to %d: %v", port, err)
+		return fmt.Errorf("failed to listen to %d: %w", port, err)
 	}
 
 	gs := grpc.NewServer()

--- a/cmd/ext-authz-server/app/app.go
+++ b/cmd/ext-authz-server/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 
 	extauthzserver "github.com/gardener/ext-authz-server/pkg/ext-authz-server"
@@ -52,7 +53,16 @@ func run(ctx context.Context, log logr.Logger, o *options) error {
 		return fmt.Errorf("failed to listen to %d: %w", port, err)
 	}
 
-	gs := grpc.NewServer()
+	var serverOpts []grpc.ServerOption
+	if o.tlsCert != "" && o.tlsKey != "" {
+		creds, err := credentials.NewServerTLSFromFile(o.tlsCert, o.tlsKey)
+		if err != nil {
+			return fmt.Errorf("failed to load TLS credentials: %w", err)
+		}
+		serverOpts = append(serverOpts, grpc.Creds(creds))
+	}
+
+	gs := grpc.NewServer(serverOpts...)
 
 	if o.reflection {
 		reflection.Register(gs)

--- a/cmd/ext-authz-server/app/app.go
+++ b/cmd/ext-authz-server/app/app.go
@@ -60,6 +60,8 @@ func run(ctx context.Context, log logr.Logger, o *options) error {
 			return fmt.Errorf("failed to load TLS credentials: %w", err)
 		}
 		serverOpts = append(serverOpts, grpc.Creds(creds))
+	} else {
+		log.Info("TLS certificates not provided, running in plaintext mode...")
 	}
 
 	gs := grpc.NewServer(serverOpts...)

--- a/cmd/ext-authz-server/app/options.go
+++ b/cmd/ext-authz-server/app/options.go
@@ -14,6 +14,8 @@ type options struct {
 	port       int
 	secretsDir string
 	reflection bool
+	tlsCert    string
+	tlsKey     string
 }
 
 func (o *options) AddFlags(fs *pflag.FlagSet) {
@@ -22,6 +24,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.port, "port", 10000, "Port of grpc server")
 	fs.StringVar(&o.secretsDir, "secrets-dir", "/secrets", "directory holding basic authentication data")
 	fs.BoolVar(&o.reflection, "grpc-reflection", false, "enable grpc reflection")
+	fs.StringVar(&o.tlsCert, "tls-cert", "/tls/tls.crt", "server certificate to use for tls communication (requires also tls-key)")
+	fs.StringVar(&o.tlsKey, "tls-key", "/tls/tls.key", "private key to use for tls communication (requires also tls-cert)")
 }
 
 func (o *options) Complete() error {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Add support for TLS and enable it by default.

Previously, the external authorization server was using plain text communication. This is not adequate for checking basic authentication as credentials are transmitted over the wire. Using TLS solves this problem.

It is still possible to fall back to plaintext communication if required by setting the certificate parameters to empty values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for TLS and enable it by default.
```
