### PR TITLE
Support legacy SHA1 htpasswd credentials

### DIFF
--- a/pkg/ext-authz-server/store.go
+++ b/pkg/ext-authz-server/store.go
@@ -5,6 +5,8 @@
 package extauthzserver
 
 import (
+	"bytes"
+	"crypto/sha1" // #nosec G505 -- needed to verify legacy SHA1 htpasswd credentials
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -45,7 +47,30 @@ func (s *store) IsValid(host string, authorization string) error {
 	if auth.username != username {
 		return errors.New("username mismatch")
 	}
-	return bcrypt.CompareHashAndPassword(auth.hashedPassword, password)
+	return comparePassword(auth.hashedPassword, password)
+}
+
+// comparePassword verifies the presented password against the stored hash.
+// It supports bcrypt ($2a$/$2y$) and legacy SHA1 ({SHA}) htpasswd formats.
+func comparePassword(storedHash, password []byte) error {
+	if bytes.HasPrefix(storedHash, []byte("{SHA}")) {
+		return compareSHA1(storedHash[len("{SHA}"):], password)
+	}
+	return bcrypt.CompareHashAndPassword(storedHash, password)
+}
+
+// compareSHA1 verifies a password against a base64-encoded SHA1 hash.
+// #nosec G401 -- needed to verify legacy SHA1 htpasswd credentials generated before June 2024
+func compareSHA1(storedBase64Hash, password []byte) error {
+	expectedHash, err := base64.StdEncoding.DecodeString(string(storedBase64Hash))
+	if err != nil {
+		return fmt.Errorf("failed to decode SHA1 hash: %w", err)
+	}
+	actualHash := sha1.Sum(password)
+	if !bytes.Equal(expectedHash, actualHash[:]) {
+		return errors.New("password mismatch")
+	}
+	return nil
 }
 
 func readSecrets(dir fs.FS) (map[string]auth, error) {

--- a/pkg/ext-authz-server/store_test.go
+++ b/pkg/ext-authz-server/store_test.go
@@ -5,6 +5,9 @@
 package extauthzserver
 
 import (
+	"crypto/sha1" // #nosec G505 -- test only
+	"encoding/base64"
+	"fmt"
 	"testing/fstest"
 
 	"github.com/gardener/gardener/pkg/utils"
@@ -15,7 +18,7 @@ import (
 
 var _ = Describe("Store", func() {
 	Describe("#readSecrets", func() {
-		It("should parse files correctly", func() {
+		It("should parse bcrypt credentials correctly", func() {
 			testFs := fstest.MapFS{
 				"app": &fstest.MapFile{
 					Data: testCredentials("foo", "bar"),
@@ -29,6 +32,19 @@ var _ = Describe("Store", func() {
 			Expect(bcrypt.CompareHashAndPassword(a.hashedPassword, []byte("bar"))).NotTo(HaveOccurred())
 		})
 
+		It("should parse SHA1 credentials correctly", func() {
+			testFs := fstest.MapFS{
+				"app": &fstest.MapFile{
+					Data: testSHA1Credentials("admin", "my-password"),
+				},
+			}
+			secrets, err := readSecrets(testFs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secrets).To(HaveKey("app"))
+			a := secrets["app"]
+			Expect(a.username).To(Equal("admin"))
+		})
+
 		It("should return error if file does not contain htpasswd format", func() {
 			testFs := fstest.MapFS{
 				"app": &fstest.MapFile{
@@ -39,6 +55,55 @@ var _ = Describe("Store", func() {
 			Expect(err).To(MatchError(ContainSubstring("does not contain valid basic auth")))
 		})
 	})
+
+	Describe("#comparePassword", func() {
+		It("should verify bcrypt password correctly", func() {
+			hashed, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(comparePassword(hashed, []byte("secret"))).To(Succeed())
+			Expect(comparePassword(hashed, []byte("wrong"))).NotTo(Succeed())
+		})
+
+		It("should verify SHA1 password correctly", func() {
+			hash := sha1.Sum([]byte("my-password")) // #nosec G401
+			storedHash := []byte("{SHA}" + base64.StdEncoding.EncodeToString(hash[:]))
+			Expect(comparePassword(storedHash, []byte("my-password"))).To(Succeed())
+			Expect(comparePassword(storedHash, []byte("wrong-password"))).NotTo(Succeed())
+		})
+
+		It("should reject invalid base64 in SHA1 hash", func() {
+			storedHash := []byte("{SHA}not-valid-base64!!!")
+			Expect(comparePassword(storedHash, []byte("anything"))).NotTo(Succeed())
+		})
+	})
+
+	Describe("#IsValid with SHA1 credentials", func() {
+		It("should accept valid credentials with SHA1 hash", func() {
+			s := &store{
+				secrets: map[string]auth{
+					"prometheus-aggregate": {
+						username:       "admin",
+						hashedPassword: sha1Hash("super-secret"),
+					},
+				},
+			}
+			header := basicAuthHeader("admin", "super-secret")
+			Expect(s.IsValid("prometheus-aggregate", header)).To(Succeed())
+		})
+
+		It("should reject wrong password with SHA1 hash", func() {
+			s := &store{
+				secrets: map[string]auth{
+					"prometheus-aggregate": {
+						username:       "admin",
+						hashedPassword: sha1Hash("correct-password"),
+					},
+				},
+			}
+			header := basicAuthHeader("admin", "wrong-password")
+			Expect(s.IsValid("prometheus-aggregate", header)).NotTo(Succeed())
+		})
+	})
 })
 
 func testCredentials(username, password string) []byte {
@@ -46,4 +111,18 @@ func testCredentials(username, password string) []byte {
 	htpasswd, err := utils.CreateBcryptCredentials([]byte(username), []byte(password))
 	Expect(err).NotTo(HaveOccurred())
 	return htpasswd
+}
+
+func testSHA1Credentials(username, password string) []byte {
+	hash := sha1.Sum([]byte(password)) // #nosec G401
+	return fmt.Appendf(nil, "%s:{SHA}%s", username, base64.StdEncoding.EncodeToString(hash[:]))
+}
+
+func sha1Hash(password string) []byte {
+	hash := sha1.Sum([]byte(password)) // #nosec G401
+	return fmt.Appendf(nil, "{SHA}%s", base64.StdEncoding.EncodeToString(hash[:]))
+}
+
+func basicAuthHeader(username, password string) string {
+	return fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", username, password)))
 }


### PR DESCRIPTION
/area monitoring
/area networking
/kind regression

**What this PR does / why we need it**:

This adds SHA1 hash verification support to the ext-authz-server, alongside the existing bcrypt support.

#### Context

In June 2024 (Gardener [v1.98.0](https://github.com/gardener/gardener/releases/tag/v1.98.0)), the password hash algorithm for basic auth secrets was changed from SHA1 to bcrypt ([`db182529c3`](https://github.com/gardener/gardener/commit/db182529c3c1badd987f7e5b20bdcc71f33f8e0a)). However, the secrets manager did not force-regenerate existing secrets. Old secrets still contain the `{SHA}` format in their `auth` field.

This was invisible while nginx ingress handled authentication (nginx supports both formats). When Gardener v1.141 replaced nginx with Istio-native exposure using this ext-authz-server (PRs gardener/gardener#14142 and gardener/gardener#14573), authentication broke for any seed or shoot whose basic auth secret pre-dates June 2024.

#### Fix

The `comparePassword` function now detects the hash format:

- `{SHA}` prefix → legacy SHA1 verification (base64-decoded, compared with `sha1.Sum`)
- Otherwise → bcrypt verification (existing behavior)

The `#nosec` annotations suppress gosec findings for `G401` (use of SHA1) and `G505` (import of crypto/sha1), since SHA1 is only used for *verification* of legacy credentials, not for generating new ones.

#### Attribution

This fix was implemented by Claude Code (Anthropic) with guidance and manual testing by @istvanballok and @vicwicker.

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/issues/14708

**Special notes for your reviewer**:

- `crypto/sha1` import is annotated with `#nosec G505` since SHA1 is only used for verification of legacy credentials.
- TODO: Revert this change once Gardener has completed migrating all existing SHA1 hashes to bcrypt (tracked via `TODO(istvanballok,vicwicker)` in the Gardener secrets manager migration code).

/cc @ScheererJ

---

<details>

<summary>How to test in the local Gardener setup</summary>

### Prerequisites

- Operator-based local Gardener setup: `make kind-multi-zone-up operator-up`, then `make operator-seed-up`
- A shoot cluster: `kubectl apply -f example/provider-local/shoot.yaml`

<details>
<summary>Step 1: Build the ext-authz-server image locally</summary>

```bash
cd /path/to/ext-authz-server

# Build the docker image for the local kind cluster (linux/amd64)
docker buildx build --platform linux/amd64 \
  -t registry.local.gardener.cloud:5001/gardener/ext-authz-server:v0.3.0-dev .

# Push to the local kind registry
docker push registry.local.gardener.cloud:5001/gardener/ext-authz-server:v0.3.0-dev
```

</details>

<details>
<summary>Step 2: Update the image vector in the Gardener source</summary>

In the Gardener repository, edit `imagevector/containers.yaml`:

```yaml
  - name: istio-basic-auth-server
    sourceRepository: github.com/gardener/ext-authz-server
    repository: registry.local.gardener.cloud:5001/gardener/ext-authz-server
    tag: "v0.3.0-dev"
```

> **Important:** Commit this change. Skaffold requires a clean or committed state to pick up the new image vector — a dirty working tree may cause the new gardenlet image (which carries the image vector) not to be propagated.

</details>

<details>
<summary>Step 3: Redeploy Gardener with the updated image</summary>

```bash
cd /path/to/gardener
make operator-up       # redeploys the operator with the updated image vector
make operator-seed-up  # reconciles the Garden resource + gardenlet
```

After `make operator-up`, the **virtual-garden** istio-basic-auth-server picks up the new image. After `make operator-seed-up`, the **seed-level** istio-basic-auth-server picks up the new image. For **shoot control planes**, trigger a shoot reconciliation:

```bash
kubectl annotate shoot local -n garden-local gardener.cloud/operation=reconcile
```

Verify all three auth server instances are using the new image:

```bash
kubectl get pods -A -o json \
  | jq '.items | map(select(.metadata.name | test("auth-server")))
    | map({namespace: .metadata.namespace, name: .metadata.name,
           images: [.spec.containers[].image]})' \
  | yq -P
```

Expected output (all three should show the local image):

```yaml
- namespace: garden
  name: istio-basic-auth-server-...
  images:
    - registry.local.gardener.cloud:5001/gardener/ext-authz-server:v0.3.0-dev
- namespace: garden
  name: virtual-garden-istio-basic-auth-server-...
  images:
    - registry.local.gardener.cloud:5001/gardener/ext-authz-server:v0.3.0-dev
- namespace: shoot--local--local
  name: istio-basic-auth-server-...
  images:
    - registry.local.gardener.cloud:5001/gardener/ext-authz-server:v0.3.0-dev
```

</details>

<details>
<summary>Step 4: Verify authentication works</summary>

#### For the aggregate Prometheus (seed-level, no shoot reconcile needed)

After upgrading Gardener (which triggers seed reconciliation), the aggregate Prometheus VirtualService and istio-basic-auth-server will be deployed.

```bash
# Test authentication against an Istio VirtualService (v1.141+)
function testAuthenticationIstio {
  if [ -z "$1" ] || [ -z "$2" ]; then
    echo "Usage: testAuthenticationIstio <namespace> <virtualservice-name>"
    return 1
  fi

  curl -v -k -sS -u $(
    kubectl get secret -n "$1" $(
      kubectl get -n "$1" virtualservices.networking.istio.io "$2" -o json \
        | jq '.metadata.labels["reference.gardener.cloud/basic-auth-secret-name"]' -r
    ) -o json | jq '.data | [.username, .password] | map(@base64d) | join(":")' -r
  ) https://$(
    kubectl get -n "$1" virtualservices.networking.istio.io "$2" -o json \
      | jq '.spec.hosts[0]' -r
  ) |& grep '< HTTP/2'
}

# Test authentication against an nginx Ingress (v1.140)
function testAuthenticationNginx {
  if [ -z "$1" ] || [ -z "$2" ]; then
    echo "Usage: testAuthenticationNginx <namespace> <ingress-name>"
    return 1
  fi

  curl -v -k -sS -u $(
    kubectl get secret -n "$1" $(
      kubectl get ingress -n "$1" "$2" -o json \
        | jq '.metadata.annotations["nginx.ingress.kubernetes.io/auth-secret"]' -r
    ) -o json | jq '.data | [.username, .password] | map(@base64d) | join(":")' -r
  ) https://$(
    kubectl get ingress -n "$1" "$2" -o json \
      | jq '.spec.rules[0].host' -r
  ) |& grep '< HTTP/2'
}

# Examples:
# Istio (v1.141): testAuthenticationIstio garden prometheus-aggregate
# Istio (shoot):  testAuthenticationIstio shoot--local--local prometheus
# Nginx (v1.140): testAuthenticationNginx garden prometheus-garden
```

#### For the shoot Prometheus (requires shoot reconcile)

The nginx→Istio migration for shoot control planes happens during shoot reconciliation.
Trigger it explicitly:

```bash
kubectl annotate shoot local -n garden-local gardener.cloud/operation=reconcile

# Wait for reconciliation to complete
kubectl get shoot local -n garden-local -w

# Then test the shoot Prometheus authentication
testAuthenticationIstio shoot--local--local prometheus
# Expected: < HTTP/2 302 (not 401)
```

</details>

<details>
<summary>Full upgrade scenario (simulating 1.140 → 1.141)</summary>

1. Deploy Gardener v1.140.2 (with the SHA1 patch from below) via `make kind-multi-zone-up operator-up`
   then `make operator-seed-up`, create a shoot: `kubectl apply -f example/provider-local/shoot.yaml`

2. Verify all secrets use SHA1 format:

   ```bash
   kubectl get secret -A -o json | jq -r '.items
     | map(select(.metadata.name | contains("observability"))
     | {namespace: .metadata.namespace, name: .metadata.name, auth: (.data.auth | @base64d)})' | yq -P
   ```

   Expected: all `auth` fields show `admin:{SHA}...`

3. Verify authentication works via nginx on all 3 layers:

   ```bash
   # Garden Prometheus (runtime cluster)
   testAuthenticationNginx garden prometheus-garden
   # Expected: < HTTP/2 302

   # Seed aggregate Prometheus
   testAuthenticationNginx garden prometheus-aggregate
   # Expected: < HTTP/2 302

   # Shoot control plane Prometheus
   testAuthenticationNginx shoot--local--local prometheus
   # Expected: < HTTP/2 302
   ```

4. Checkout Gardener v1.141 (or master), patch `imagevector/containers.yaml`
   to use the locally built ext-authz-server image (see Step 2), **commit the change**

5. Upgrade and migrate:

   ```bash
   make operator-up                        # updates the operator (no migration yet)
   kubectl annotate garden local gardener.cloud/operation=reconcile  # triggers garden reconcile, deploys basic-auth-server
   make operator-seed-up                   # reconciles seed, deploys gardenlet with new image vector
   kubectl annotate shoot local -n garden-local gardener.cloud/operation=reconcile  # triggers shoot reconcile
   ```

6. Observe the nginx→Istio migration:

   ```bash
   # nginx Ingresses should disappear
   kubectl get ingress -A
   # Istio VirtualServices should appear
   kubectl get virtualservices.networking.istio.io -A
   ```

7. Verify authentication works via Istio on all 3 layers (SHA1 secrets, new ext-authz-server):

   ```bash
   # Garden Prometheus (virtual garden)
   testAuthenticationIstio garden virtual-garden-prometheus-garden
   # Expected: < HTTP/2 302

   # Seed aggregate Prometheus
   testAuthenticationIstio garden prometheus-aggregate
   # Expected: < HTTP/2 302

   # Shoot control plane Prometheus
   testAuthenticationIstio shoot--local--local prometheus
   # Expected: < HTTP/2 302
   ```

</details>

<details>
<summary>Simulating pre-existing SHA1 secrets</summary>

To properly test the migration scenario, deploy Gardener v1.140.2 with a patch that forces SHA1 hash generation (simulating a landscape that has been running since before June 2024).

Apply the following patch to Gardener v1.140.2 before deploying:

```bash
cd /path/to/gardener
git checkout v1.140.2
git am <<'PATCH'
From 316333ced3d03689688c62338118c0fa10a014c2 Mon Sep 17 00:00:00 2001
From: Istvan Zoltan Ballok <istvan.zoltan.ballok@sap.com>
Date: Tue, 28 Apr 2026 14:40:10 +0200
Subject: [PATCH] [TEST ONLY] Generate basic auth secrets with SHA1 hash

This patch reverts the hash algorithm to SHA1 for testing purposes.
Apply it to v1.140.2 to simulate a landscape with pre-June-2024 secrets,
then upgrade to v1.141 (without this patch) to verify that the
ext-authz-server correctly handles legacy SHA1 credentials.

DO NOT MERGE - this is a test-only patch.
---
 pkg/utils/encoding.go           | 9 +++++++++
 pkg/utils/secrets/basic_auth.go | 5 +----
 2 files changed, 10 insertions(+), 4 deletions(-)

diff --git a/pkg/utils/encoding.go b/pkg/utils/encoding.go
index 2ee30bc1d9..4c583d8f63 100644
--- a/pkg/utils/encoding.go
+++ b/pkg/utils/encoding.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -124,6 +125,14 @@ func CreateBcryptCredentials(username, password []byte) ([]byte, error) {
 	return credentials, nil
 }
 
+// CreateSHA1Secret takes a username and a password and returns a SHA1-schemed credentials pair as bytes.
+func CreateSHA1Secret(username, password []byte) []byte {
+	hash := sha1.Sum(password)
+	credentials := append(username, ":{SHA}"...)
+	credentials = append(credentials, []byte(base64.StdEncoding.EncodeToString(hash[:]))...)
+	return credentials
+}
+
 // ComputeSHA256Hex computes the hexadecimal representation of the SHA256 hash of the given input byte
 // slice <in>, converts it to a string and returns it.
 func ComputeSHA256Hex(in []byte) string {
diff --git a/pkg/utils/secrets/basic_auth.go b/pkg/utils/secrets/basic_auth.go
index ac7c1481df..12c1b4fcf2 100644
--- a/pkg/utils/secrets/basic_auth.go
+++ b/pkg/utils/secrets/basic_auth.go
@@ -59,10 +59,7 @@ func (s *BasicAuthSecretConfig) Generate() (DataInterface, error) {
 		return nil, err
 	}
 
-	auth, err := utils.CreateBcryptCredentials([]byte(s.Username), []byte(password))
-	if err != nil {
-		return nil, err
-	}
+	auth := utils.CreateSHA1Secret([]byte(s.Username), []byte(password))
 
 	basicAuth := &BasicAuth{
 		Name: s.Name,
-- 
2.54.0
PATCH
```

Then deploy with `make kind-multi-zone-up operator-up` and `make operator-seed-up`, create a shoot, and verify the secrets have SHA1 format:

```bash
NAMESPACE=$(kubectl get ns -l gardener.cloud/role=shoot -o name | head -1 | cut -d/ -f2)
SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -l name=observability-ingress-users -o name | head -1)
kubectl get "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.auth}' | base64 -d
# Expected: admin:{SHA}...
```

Now upgrade to v1.141 (without the patch, with the new ext-authz-server image) and verify that both the old SHA1 secrets and newly generated bcrypt secrets work.

</details>

### Inspecting the secret format

To check whether a secret has SHA1 or bcrypt format:

```bash
kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.auth}' | base64 -d
```

- `admin:{SHA}...` → legacy SHA1 (this PR makes it work)
- `admin:$2a$10$...` → bcrypt (already works)

---

</details>

**Release note**:

```bugfix user
In combination with Gardener v1.141, monitoring ingress authentication now works for landscapes with pre-June-2024 basic auth secrets that still use SHA1 password hashes.
```

```feature developer
Temporarily support SHA1 (`{SHA}` prefix) htpasswd format for password verification, alongside bcrypt. This enables backwards compatibility with legacy basic auth secrets until Gardener completes the migration to bcrypt.
```
